### PR TITLE
增加host配置，解决读取url和上传时endpoint的冲突，并且可以设置cdn自定义域名。

### DIFF
--- a/lib/carrierwave/aliyun/bucket.rb
+++ b/lib/carrierwave/aliyun/bucket.rb
@@ -9,6 +9,13 @@ module CarrierWave
         @aliyun_endpoint     = uploader.aliyun_endpoint
         @aliyun_bucket       = uploader.aliyun_bucket
         @aliyun_region         = uploader.aliyun_region
+
+        # Host for get request
+        @aliyun_host = uploader.aliyun_host || "https://#{@aliyun_bucket}.#{@aliyun_endpoint}"
+
+        unless @aliyun_host.include?('//')
+          raise "config.aliyun_host requirement include // http:// or https://, but you give: #{@aliyun_host}"
+        end
       end
 
       # 上传文件
@@ -76,9 +83,9 @@ module CarrierWave
       def path_to_url(path, opts = {})
         if opts[:thumb]
           thumb_path = [path, opts[:thumb]].join('')
-          [@aliyun_endpoint, thumb_path].join('/')
+          [@aliyun_host, thumb_path].join('/')
         else
-          [@aliyun_endpoint, path].join('/')
+          [@aliyun_host, path].join('/')
         end
       end
 

--- a/lib/carrierwave/aliyun/configuration.rb
+++ b/lib/carrierwave/aliyun/configuration.rb
@@ -9,6 +9,7 @@ module CarrierWave
         add_config :aliyun_endpoint
         add_config :aliyun_bucket
         add_config :aliyun_region
+        add_config :aliyun_host
 
         configure do |config|
           config.storage_engines[:aliyun] = 'CarrierWave::Storage::Aliyun'


### PR DESCRIPTION
官方的endpoint是形如"oss-#{ENV['aliyun_area']}.aliyuncs.com"，最终获取的资源url应该是
"http://#{ENV["aliyun_bucket"]}.oss-#{ENV['aliyun_area']}.aliyuncs.com"的形式，在上传文件时，sdk会拼接bucket_name和area得到最终上传url，因此参考huacnlee的实现增加host config配置。